### PR TITLE
Add mailing list info when appropriate

### DIFF
--- a/.note.xml
+++ b/.note.xml
@@ -1,4 +1,8 @@
 <note title="Discussion Venues" removeInRFC="true">
+<t>Discussion of this document takes place on the
+      "Media Over QUIC" non-working group mailing list (MOQ),
+    which is archived at <eref target="https://mailarchive.ietf.org/arch/browse/moq/"/>.
+    Subscription information is at <eref target="https://www.ietf.org/mailman/listinfo/Moq/"/>.</t>
 <t>Source for this draft and an issue tracker can be found at
     <eref target="https://github.com/fiestajetsam/draft-gruessing-moq-requirements"/>.</t>
 </note>


### PR DESCRIPTION
I'll let you decide when you want to include this (almost certainly "not now", and better after we have more content). I'm just adding this so we don't forget it when we go public. 