### PR TITLE
Propose near-real time latency

### DIFF
--- a/draft-gruessing-moq-requirements.md
+++ b/draft-gruessing-moq-requirements.md
@@ -187,7 +187,7 @@ Within this document, we extend the latency requirement categories for streaming
 
 These latency bands were appropriate for streaming media, which was the target for {{I-D.draft-ietf-mops-streaming-opcons}}, but some interactive media may have requirements that are significantly less than "ultra-low latency". Within this document, we are also using
 
-- Ull-50 (less than 50 ms)
+- near real-time (less than 50 ms)
 - Ull-200 (less than 200 ms)
 
 Perhaps obviously, these last two latency bands are the shortened form of "ultra-low latency - 50 ms" and "ultra-low-latency - 200 ms". Perhaps less obviously, bikeshedding on better names and more useful values is welcomed.


### PR DESCRIPTION
I propose defining latencies less than 50 ms as near real-time latencies.
These latencies can be used by musicians to play together in sync. And I guess the human ear or eye would mostly not notice any delay below 50 ms.
Might be worth doing a bit of research around the topic to refine the ranges though.
For instance, in this paper (https://ieeexplore.ieee.org/document/5540888) they conclude:
> ... the visual response latency ranges from 74ms to 106ms...


In another source (https://www.pubnub.com/blog/how-fast-is-realtime-human-perception-and-technology/) the following is defined:
> 300ms < game is unplayable
    150ms  < game play degraded 
    100ms < player performance affected
    50ms   > target performance
    13ms    > lower detectable limit
