### PR TITLE
Cleanup of "Packaging Media" requirements section.

### DIFF
--- a/draft-gruessing-moq-requirements.md
+++ b/draft-gruessing-moq-requirements.md
@@ -41,6 +41,10 @@ informative:
   I-D.draft-jennings-moq-quicr-proto:
   I-D.draft-ietf-webtrans-overview:
 
+  ISOBMFF:
+    title: "Information Technology - Coding Of Audio-Visual Objects - Part 12: ISO Base Media File Format"
+    date: 2022
+
   MOQ-charter:
     target: https://datatracker.ietf.org/wg/moq/about/
     title: "Media Over QUIC (moq)"
@@ -264,12 +268,18 @@ As multiple streams of media may be available for concurrent sending such as mul
 
 ## Packaging Media {#Packaging}
 
-Packaging of media describes how encapsulation of media to carry the raw media will work. There are at a high level two approaches to this:
+Packaging of media describes how raw media will be encapsulated. There are at a high level two approaches to this:
 
-* Within the protocol itself, where the protocol defines the carrying for each media encoding the ancillary data required for decoding the media.
-* A common encapsulation format such as ISOBMFF which defines a generic method for all media and handles ancillary decode information.
+* Within the protocol itself, where the protocol defines the ancillary data required to decode each media type the protocol supports.
+* A common encapsulation format such as ISOBMFF {{ISOBMFF}} which defines a generic method for all media and handles ancillary decode information.
 
-The working group must agree on which approach should be taken to the packaging of media, taking into consideration the various technical trade offs that each provide. If the working group decides on a common encapsulation format, the mechanisms within the protocol SHOULD allow for new encapsulation formats to be used.
+The working group must agree on which approach should be taken to the packaging of media, taking into consideration the various technical trade offs that each approach provides.
+
+- If the working group decides to describe media encapsulation as part of the MOQ protocol, this will require a new version of the MOQ protocol in order to signal the receiver that a new media encapsulation format may be present.
+
+- If the working group decides to use a common encapsulation format, the mechanisms within the protocol SHOULD allow for new encapsulation formats to be used. Without encapsulation agility, adding or changing the way media is encapsulated will also require a new version of the MOQ protocol, to signal the receiver that a new media encapsulation format may be present.
+
+MOQ protocol specifications will provide details on the supported media encapsulation(s).
 
 ## Media Consumption {#med-consumption}
 


### PR DESCRIPTION
@fiestajetsam - I am looking at [Section 12 of the WARP draft](https://kixelated.github.io/warp-draft/draft-lcurley-warp.html#name-containers), and wondering if I understand our point in our draft.

Is it accurate to describe what WARP-04 is doing now, as 

> describes how raw media will be encapsulated within the protocol itself, where the protocol defines the ancillary data required to decode each media type the protocol supports.

?

If I understand the point, it's that we have to rev the specification, and implementations, in order to add a new package (because implementations that only support Container Format 0x0 for fMP4 don't know what to do with Container Format 0x1), so the distinction we are making seems (to me) to be about whether the protocol specification uses a generic method to tell a receiver how to decode media, rather than whether the protocol specification describes methods itself. 

Please let me know what you think, because I'm pretty sure I know what I want to say, unless I'm confused. 